### PR TITLE
Update log4j version

### DIFF
--- a/deer-cli/pom.xml
+++ b/deer-cli/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.11.1</version>
+      <version>2.17.1</version>
       <scope>runtime</scope>
     </dependency>
 


### PR DESCRIPTION
Update the log4j-slf4j-impl version to fix several log4j vulnerabilities (See https://logging.apache.org/log4j/2.x/security.html).